### PR TITLE
Remove `PageItem.__repr__`

### DIFF
--- a/src/pycrunchbase/resource/pageitem.py
+++ b/src/pycrunchbase/resource/pageitem.py
@@ -44,6 +44,9 @@ class PageItem(object):
     def __repr__(self):
         return self.__str__()
 
+    def __str__(self):
+        return 'PageItem: %s' % self.data
+
 
 class UuidPageItem(PageItem):
     def __init__(self, data):

--- a/tests/test_pageitem.py
+++ b/tests/test_pageitem.py
@@ -269,3 +269,11 @@ class PageItemTestCase(TestCase):
         except:
             # py3
             self.assertEqual(u'å Last', str(page_item))
+
+    def test_repr(self):
+        page_item = PageItem.build({'sample': 'data'})
+        assert repr(page_item) == "PageItem: {'sample': 'data'}"
+
+    def test_str(self):
+        page_item = PageItem.build({'sample': 'data'})
+        assert str(page_item) == "PageItem: {'sample': 'data'}"


### PR DESCRIPTION
Most classes implement `__str__`, and then implement `__repr__` to proxy to `__str__`.  `PageItem`, however, does not implement `__str__`, but _does_ implement the `__repr__` proxy to `__str__`, and thus a call to `__repr__` calls Python's internal `__str__`, which calls `__repr__` resulting in a recursion exception.

The easiest fix is to remove `PageItem.__repr__` until/if `PageItem.__str__` is ever implemented.