### PR TITLE
Flexible requests/six versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
         "crunchbase"
     ],
     install_requires=[
-        "requests>=2.20.0", "six==1.9.0"
+        "requests>=2.20.0", "six>=1.9.0"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
         "crunchbase"
     ],
     install_requires=[
-        "requests==2.20.0", "six==1.9.0"
+        "requests>=2.20.0", "six==1.9.0"
     ],
 )


### PR DESCRIPTION
Heya

The requirements specified in `setup.py` pin the two dependencies to very specific versions, resulting in unresolvable conflicts with the [new pip resolver](http://pyfound.blogspot.com/2020/11/pip-20-3-new-resolver.html). There's no reason to pin to such specific version numbers.

Thank you!